### PR TITLE
ci: add Rust CI workflow, cargo-deny and typos config (closes #19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,36 +2,111 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [apotheosis2]
   pull_request:
-    branches:
-      - main
+    branches: [apotheosis2]
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  fmt:
+    name: Format
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-features
+
+  build:
+    name: Release build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --all-features
+
+  deny:
+    name: Deny (licenses + advisories)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
+  cross:
+    name: Cross-platform (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        tests: ["Unit tests"]
-
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-features
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1
+
+  msrv:
+    name: MSRV (1.88)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.88
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-features
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          python-version: 3.9
-
-      - name: Install system dependencies
-        run: sudo apt install -y libfuzzy-dev
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-      - name: Run tests
-        run: python -m unittest tests/unit.py 
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --all-features --html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: target/llvm-cov/html/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "apotheosis2"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88"
 
 [dependencies]
 rand_pcg = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "apotheosis2"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
+license = "GPL-3.0-only"
 
 [dependencies]
 rand_pcg = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ APOTHEOSIS (*APprOximaTe searcH systEm Of Similarity dIgeSts*) is a powerful sys
 
 
 # System configuration parameters
-In order to reach the proper balance between precission and speed, some configuration values can be modified in order to tune the performance. This configuration values have impact on HNSW data structure mainly. Values may be adjusted depending on your use case.
+In order to reach the proper balance between precision and speed, some configuration values can be modified in order to tune the performance. This configuration values have impact on HNSW data structure mainly. Values may be adjusted depending on your use case.
 
 - *M*: specifies the maximum number of neighbors (connections) a node can have at each layer of the hierarchy higher than zero.
 - *M0*: specifies the maximum number of neighbors (connections) a node can have at each layer of the hierarchy at layer zero.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,5 @@
+[default.extend-words]
+# Spanish words in README.md's Funding support section (INCIBE grant name).
+# typos uses an English dictionary and would flag these as misspellings.
+Estratégicos = "Estratégicos"
+Ciberseguridad = "Ciberseguridad"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,5 @@
 [default.extend-words]
 # Spanish words in README.md's Funding support section (INCIBE grant name).
 # typos uses an English dictionary and would flag these as misspellings.
-Estratégicos = "Estratégicos"
+"Estratégicos" = "Estratégicos"
 Ciberseguridad = "Ciberseguridad"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+[advisories]
+# Deny crates with known security vulnerabilities (CVEs).
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+ignore = [
+    # bincode 1.3.3 is unmaintained (RUSTSEC-2025-0141) but has no safe upgrade.
+    # Upstream uses it for serialization; migration is tracked as a known issue.
+    "RUSTSEC-2025-0141",
+    # quick-xml 0.36.2 via gexf 0.1.1 (no newer gexf release available).
+    # These vulnerabilities affect untrusted XML parsing; gexf is used only
+    # for visualization output of internal graph data, not for parsing untrusted input.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]
+
+[licenses]
+version = 2
+# Licenses compatible with GPL-3.0 (permissive licenses can be used in GPL projects).
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Unicode-3.0",
+    "GPL-3.0-only",
+]
+
+[bans]
+# Warn on duplicate versions of the same crate (can indicate dependency bloat).
+multiple-versions = "warn"
+# tlsh2 is a git dependency with no semver version - wildcard is intentional.
+wildcards = "warn"
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# tlsh2 is fetched directly from GitHub - this is intentional.
+allow-git = ["https://github.com/danielhuici/tlsh"]

--- a/src/bin/test_numbers.rs
+++ b/src/bin/test_numbers.rs
@@ -4,7 +4,6 @@ use apotheosis2::datalayer::record::{ApotheosisRecord, SimpleNumberRecord};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use std::time::Instant;
-use std::u32::MAX;
 
 // cargo run --bin test_numbers
 pub fn main() {
@@ -42,18 +41,18 @@ pub fn main() {
     let mut all_results = Vec::new();
 
     // Brute force search for neighbors
-    let mut closest = (MAX, MAX);
+    let mut closest = (u32::MAX, u32::MAX);
     let mut brute_results: Vec<(u32, u32)> = vec![];
     for n in random_queries.iter() {
         for n2 in &random_numbers {
-            let dist = if n2 > n { n2 - n } else { n - n2 };
+            let dist = n2.abs_diff(*n);
             if dist < closest.0 {
                 closest.0 = dist;
                 closest.1 = *n2;
             }
         }
         brute_results.push(closest);
-        closest = (MAX, MAX);
+        closest = (u32::MAX, u32::MAX);
     }
 
     //println!("{:?}", brute_results);

--- a/src/bin/test_tlsh.rs
+++ b/src/bin/test_tlsh.rs
@@ -12,13 +12,13 @@ fn read_hashes_from_json<P: AsRef<std::path::Path>>(path: P) -> Vec<String> {
     let v: Value = serde_json::from_str(&data).expect("Failed to parse JSON");
     let obj = v.as_object().expect("Expected JSON object at root");
 
-    if let Some(hashes_value) = obj.get("hashes") {
-        if let Some(hashes_array) = hashes_value.as_array() {
-            return hashes_array
-                .iter()
-                .filter_map(|val| val.as_str().map(|s| s.to_string()))
-                .collect();
-        }
+    if let Some(hashes_value) = obj.get("hashes")
+        && let Some(hashes_array) = hashes_value.as_array()
+    {
+        return hashes_array
+            .iter()
+            .filter_map(|val| val.as_str().map(|s| s.to_string()))
+            .collect();
     }
 
     Vec::new()
@@ -74,7 +74,7 @@ pub fn main() {
             let diff = tlsh_query.diff(&tlsh_candidate, true) as u32;
             if diff < closest.0 {
                 closest.0 = diff;
-                closest.1 = Some(&candidate);
+                closest.1 = Some(candidate);
             }
         }
 

--- a/src/controllers/apotheosis.rs
+++ b/src/controllers/apotheosis.rs
@@ -46,7 +46,25 @@ where
             records: vec![],
         }
     }
+}
 
+impl<R, D, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool> Default
+    for Apotheosis<R, D, M, M0, EF, HEURISTIC>
+where
+    R: ApotheosisRecord,
+    D: DistanceAlgorithm<R::MetricId> + Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R, D, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool>
+    Apotheosis<R, D, M, M0, EF, HEURISTIC>
+where
+    R: ApotheosisRecord,
+    D: DistanceAlgorithm<R::MetricId> + Default,
+{
     /// Inserts an ApotheosisRecord into the Apotheosis Model (radix tree + HNSW + vector metadata).
     /// The record's `search_id` is stored in HNSW for similarity search, the `radix_key` is mapped
     /// to the record's index, and the record itself is stored for later retrieval.
@@ -60,11 +78,11 @@ where
     pub fn insert(&mut self, item: R) -> bool {
         let radix_key = item.search_id().to_radix_key();
 
-        if let Some(ref key) = radix_key {
-            if self.radix.find(key).is_some() {
-                println!("Key already exists in radix tree: {:?}", key);
-                return false;
-            }
+        if let Some(ref key) = radix_key
+            && self.radix.find(key).is_some()
+        {
+            println!("Key already exists in radix tree: {:?}", key);
+            return false;
         }
 
         let hnsw_node_index = self.hnsw.insert(item.search_id());
@@ -179,7 +197,6 @@ where
     ///
     /// # Parameters
     /// * `path` - Base filename for output (e.g., "model" creates "model_layer0.gexf", "model_layer1.gexf", etc.)
-
     pub fn draw<P: AsRef<Path>>(&self, path: P) {
         let base_path = path.as_ref();
 
@@ -203,7 +220,7 @@ where
                         source_id.clone(),
                         target_id.clone(),
                     )
-                    .with_weight(distance.clone()),
+                    .with_weight(*distance),
                 );
             }
 
@@ -214,26 +231,26 @@ where
     // Once draw is built, we need to add the attribute schema to the GEXF XML
     // Has to be done manually since gexf crate does not support it yet.
     fn add_attribute_schema(&self, xml: String, attributes: Vec<(String, String)>) -> String {
-        if let Some(graph_start) = xml.find("<graph") {
-            if let Some(graph_end_offset) = xml[graph_start..].find(">") {
-                let insert_pos = graph_start + graph_end_offset + 1;
+        if let Some(graph_start) = xml.find("<graph")
+            && let Some(graph_end_offset) = xml[graph_start..].find(">")
+        {
+            let insert_pos = graph_start + graph_end_offset + 1;
 
-                let mut attrs = String::from("\n    <attributes class=\"node\">\n");
-                for (attribute_key, _) in attributes {
-                    attrs.push_str(&format!(
-                        "      <attribute id=\"{}\" title=\"{}\" type=\"string\"/>\n",
-                        attribute_key, attribute_key
-                    ));
-                }
-                attrs.push_str("    </attributes>\n");
-
-                let mut result = String::new();
-                result.push_str(&xml[..insert_pos]);
-                result.push_str(&attrs);
-                result.push_str(&xml[insert_pos..]);
-
-                return result;
+            let mut attrs = String::from("\n    <attributes class=\"node\">\n");
+            for (attribute_key, _) in attributes {
+                attrs.push_str(&format!(
+                    "      <attribute id=\"{}\" title=\"{}\" type=\"string\"/>\n",
+                    attribute_key, attribute_key
+                ));
             }
+            attrs.push_str("    </attributes>\n");
+
+            let mut result = String::new();
+            result.push_str(&xml[..insert_pos]);
+            result.push_str(&attrs);
+            result.push_str(&xml[insert_pos..]);
+
+            return result;
         }
 
         xml

--- a/src/controllers/hnsw.rs
+++ b/src/controllers/hnsw.rs
@@ -36,6 +36,16 @@ pub struct Hnsw<
     distance: D,
 }
 
+impl<D, ID, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool> Default
+    for Hnsw<D, ID, M, M0, EF, HEURISTIC>
+where
+    D: DistanceAlgorithm<ID> + Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<D, ID, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool>
     Hnsw<D, ID, M, M0, EF, HEURISTIC>
 where
@@ -107,7 +117,7 @@ where
                 knn_neighbors.len()
             );
             if HEURISTIC {
-                self.add_node_heuristic(&mut knn_neighbors, Some(layer_ix));
+                self.add_node_heuristic(&knn_neighbors, Some(layer_ix));
             } else {
                 self.add_node(&mut knn_neighbors, Some(layer_ix));
             }
@@ -127,7 +137,7 @@ where
             &mut visited_neighbors,
         );
         if HEURISTIC {
-            self.add_node_heuristic(&mut knn_neighbors, None);
+            self.add_node_heuristic(&knn_neighbors, None);
         } else {
             self.add_node(&mut knn_neighbors, None);
         }
@@ -135,7 +145,7 @@ where
         // Create new layers up to new_level
         while self.upper_layers.len() < insertion_level {
             let node = HnswNode {
-                next_node: if self.upper_layers.len() != 0 {
+                next_node: if !self.upper_layers.is_empty() {
                     self.upper_layers.last().unwrap().len() as u32 - 1
                 } else {
                     self.zero_layer.len() as u32 - 1
@@ -150,7 +160,7 @@ where
 
         //self.print_layers();
 
-        return feature_ref;
+        feature_ref
     }
 
     pub fn initialize(&mut self, insertion_level: usize) {
@@ -290,11 +300,7 @@ where
     }
 
     #[inline]
-    fn add_node_heuristic(
-        &mut self,
-        new_neighbors: &mut Vec<(usize, u32)>,
-        layer_idx: Option<usize>,
-    ) {
+    fn add_node_heuristic(&mut self, new_neighbors: &[(usize, u32)], layer_idx: Option<usize>) {
         let new_feature_idx = self.features.len() - 1;
 
         let new_node_index = match layer_idx {
@@ -628,7 +634,7 @@ where
     }
 
     fn random_level(&mut self) -> usize {
-        let uniform: f64 = self.prng.next_u64() as f64 / core::u64::MAX as f64;
+        let uniform: f64 = self.prng.next_u64() as f64 / u64::MAX as f64;
         (-libm::log(uniform) * libm::log(M as f64).recip()) as usize
     }
 
@@ -745,6 +751,7 @@ where
         results
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn draw_model(&self) -> Vec<(Vec<usize>, Vec<(String, String, f32)>)> {
         let mut layer_gexfs = Vec::new();
 

--- a/src/controllers/hnsw.rs
+++ b/src/controllers/hnsw.rs
@@ -227,7 +227,7 @@ where
                 self.connect_neighbors(new_node_index, new_neighbors, Some(idx));
             }
             None => {
-                // Zero layer insetion
+                // Zero layer insertion
                 let new_node_index = self.zero_layer.len() as u32;
                 let mut neighbors = [!0; M0];
                 let mut neighbor_distances = [!0; M0];
@@ -394,7 +394,7 @@ where
                         neighbor_node.neighbor_distances[slot] = new_distance;
                         neighbor_node.neighbor_count += 1;
                     } else {
-                        // Neighbor list is full, replace it with the farest one
+                        // Neighbor list is full, replace it with the farthest one
                         let (worst_ix, worst_distance) = neighbor_node
                             .active_distances()
                             .iter()
@@ -734,9 +734,9 @@ where
         ));
 
         let node = &self.zero_layer[index];
-        let neigbors = node.active_neighbors();
+        let neighbors = node.active_neighbors();
 
-        for neighbor_index in neigbors {
+        for neighbor_index in neighbors {
             let score = self.distance.calculate_distance(
                 &self.features[*neighbor_index as usize],
                 &self.features[node.feature_index as usize],

--- a/src/controllers/hnsw.rs
+++ b/src/controllers/hnsw.rs
@@ -1,7 +1,7 @@
 use crate::datalayer::algorithms::DistanceAlgorithm;
 use crate::datalayer::nodes::HnswNode;
-use core::cmp::min;
 use core::cmp::Reverse;
+use core::cmp::min;
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 use std::cmp;
@@ -18,8 +18,14 @@ fn default_rng() -> StdRng {
     serialize = "ID: serde::Serialize, D: DistanceAlgorithm<ID> + serde::Serialize",
     deserialize = "ID: serde::Deserialize<'de>, D: DistanceAlgorithm<ID> + serde::Deserialize<'de>"
 ))]
-pub struct Hnsw<D, ID, const M: usize, const M0: usize, const EF: usize = 400, const HEURISTIC: bool = false>
-where
+pub struct Hnsw<
+    D,
+    ID,
+    const M: usize,
+    const M0: usize,
+    const EF: usize = 400,
+    const HEURISTIC: bool = false,
+> where
     D: DistanceAlgorithm<ID> + Default,
 {
     features: Vec<ID>,
@@ -30,7 +36,8 @@ where
     distance: D,
 }
 
-impl<D, ID, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool> Hnsw<D, ID, M, M0, EF, HEURISTIC>
+impl<D, ID, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool>
+    Hnsw<D, ID, M, M0, EF, HEURISTIC>
 where
     D: DistanceAlgorithm<ID> + Default,
 {
@@ -253,26 +260,41 @@ where
         // Iterate each neighbor to see who's a better link. Our new node, or some of the new neighbors?
         for &(cand_node, candidate_feature_idx, candidate_distance) in candidates {
             // Greedy set cover, this is, we only check candidate against ALREADY-SELECTED (confirmed) neighbors
-            let is_new_node_best_candidate = new_confirmed_neighbors.iter().all(|&(_, selected_feature_idx, _)| { 
-                self.distance.calculate_distance(
-                    &self.features[candidate_feature_idx],
-                    &self.features[selected_feature_idx],
-                ) >= candidate_distance
-            });
+            let is_new_node_best_candidate =
+                new_confirmed_neighbors
+                    .iter()
+                    .all(|&(_, selected_feature_idx, _)| {
+                        self.distance.calculate_distance(
+                            &self.features[candidate_feature_idx],
+                            &self.features[selected_feature_idx],
+                        ) >= candidate_distance
+                    });
 
-            if is_new_node_best_candidate { // The node we are inserting is the best link
-                new_confirmed_neighbors.push((cand_node, candidate_feature_idx, candidate_distance));
+            if is_new_node_best_candidate {
+                // The node we are inserting is the best link
+                new_confirmed_neighbors.push((
+                    cand_node,
+                    candidate_feature_idx,
+                    candidate_distance,
+                ));
                 if new_confirmed_neighbors.len() == max_neighbors {
                     break;
                 }
             } // Else, some of the other neighbors is better than us (and will be linked to it later)!
         }
 
-        new_confirmed_neighbors.iter().map(|&(node, _, dist)| (node, dist)).collect()
+        new_confirmed_neighbors
+            .iter()
+            .map(|&(node, _, dist)| (node, dist))
+            .collect()
     }
 
     #[inline]
-    fn add_node_heuristic(&mut self, new_neighbors: &mut Vec<(usize, u32)>, layer_idx: Option<usize>) {
+    fn add_node_heuristic(
+        &mut self,
+        new_neighbors: &mut Vec<(usize, u32)>,
+        layer_idx: Option<usize>,
+    ) {
         let new_feature_idx = self.features.len() - 1;
 
         let new_node_index = match layer_idx {
@@ -280,7 +302,6 @@ where
             None => self.zero_layer.len() as u32,
         };
 
-        
         let candidates: Vec<(u32, usize, u32)> = new_neighbors // (neighbor_idx, feature_idx, distance)
             .iter()
             .map(|&(node, dist)| {
@@ -319,7 +340,8 @@ where
                     neighbor_count: selected.len() as u16,
                 });
 
-                let selected_as_usize: Vec<(usize, u32)> = selected.iter().map(|&(n, d)| (n as usize, d)).collect();
+                let selected_as_usize: Vec<(usize, u32)> =
+                    selected.iter().map(|&(n, d)| (n as usize, d)).collect();
                 self.connect_neighbors_heuristic(new_node_index, &selected_as_usize, Some(idx));
             }
             None => {
@@ -338,7 +360,8 @@ where
                     neighbor_count: selected.len() as u16,
                 });
 
-                let selected_as_usize: Vec<(usize, u32)> = selected.iter().map(|&(n, d)| (n as usize, d)).collect();
+                let selected_as_usize: Vec<(usize, u32)> =
+                    selected.iter().map(|&(n, d)| (n as usize, d)).collect();
                 self.connect_neighbors_heuristic(new_node_index, &selected_as_usize, None);
             }
         }
@@ -358,12 +381,14 @@ where
                 for &(neighbor_idx, new_distance) in new_neighbors {
                     let neighbor_node = &mut self.upper_layers[idx][neighbor_idx];
 
-                    if (neighbor_node.neighbor_count as usize) < M { // We have space on the neighbor's list. Just add it.
+                    if (neighbor_node.neighbor_count as usize) < M {
+                        // We have space on the neighbor's list. Just add it.
                         let slot = neighbor_node.neighbor_count as usize;
                         neighbor_node.neighbors[slot] = new_node_index;
                         neighbor_node.neighbor_distances[slot] = new_distance;
                         neighbor_node.neighbor_count += 1;
-                    } else { // Neighbor list is full, replace it with the farest one
+                    } else {
+                        // Neighbor list is full, replace it with the farest one
                         let (worst_ix, worst_distance) = neighbor_node
                             .active_distances()
                             .iter()
@@ -371,7 +396,8 @@ where
                             .max_by_key(|&(_, &distance)| distance)
                             .unwrap();
 
-                        if new_distance < *worst_distance { // Bidirecionally connect the nodes ONLY if we have space
+                        if new_distance < *worst_distance {
+                            // Bidirecionally connect the nodes ONLY if we have space
                             neighbor_node.neighbors[worst_ix] = new_node_index;
                             neighbor_node.neighbor_distances[worst_ix] = new_distance;
                         }
@@ -437,17 +463,16 @@ where
                 };
 
                 let feature: usize = match layer_idx {
-                        Some(idx) => self.upper_layers[idx][node as usize].feature_index as usize,
-                        None => self.zero_layer[node as usize].feature_index as usize,
-                    };
-                
+                    Some(idx) => self.upper_layers[idx][node as usize].feature_index as usize,
+                    None => self.zero_layer[node as usize].feature_index as usize,
+                };
+
                 candidates.push((node, feature, distance_to_new_node));
             }
             // We also include the new node.
             candidates.push((new_node_index, new_node_feature_idx, new_distance));
             // Required: select_neighbors_heuristic() needs candidates in ascending distance order.
             candidates.sort_by_key(|&(_, _, d)| d);
-
 
             // Now, evaluate each new neighbor's neighbor list VS. the new node, BUT WITH HEURISTIC!
             // Second time we call here and some ops may be redundant, could this be cached somehow or i'm just rambling?
@@ -486,7 +511,7 @@ where
     ) -> Vec<(usize, u32)> {
         let mut candidates: BinaryHeap<Reverse<(u32, usize)>> = BinaryHeap::with_capacity(ef); // Min heap
         candidates.push(Reverse((score, enter_point)));
-        let mut currently_found_nearest_neighbors: BinaryHeap<(u32, usize)> = 
+        let mut currently_found_nearest_neighbors: BinaryHeap<(u32, usize)> =
             BinaryHeap::with_capacity(ef + 1); // Max heap
         currently_found_nearest_neighbors.push((score, enter_point));
 
@@ -510,20 +535,21 @@ where
                     self.upper_layers[layer_idx - 1][*neighbor as usize].feature_index as usize;
                 debug!("    [S2] Exploring neighbor: {:?}", neighbor);
 
-                if visited_neighbors.insert(neighbor_feature_index) { // We have NOT visited the current neighbor
+                if visited_neighbors.insert(neighbor_feature_index) {
+                    // We have NOT visited the current neighbor
                     let score = self
                         .distance
                         .calculate_distance(&self.features[neighbor_feature_index], query_feature);
 
-                    
-                    if currently_found_nearest_neighbors.len() < ef || 
-                        score < currently_found_nearest_neighbors.peek().unwrap().0 {
-                            candidates.push(Reverse((score, *neighbor as usize)));
-                            currently_found_nearest_neighbors.push((score, *neighbor as usize));
-                            if currently_found_nearest_neighbors.len() > ef {
-                                currently_found_nearest_neighbors.pop(); // evict the farthest
-                            }
+                    if currently_found_nearest_neighbors.len() < ef
+                        || score < currently_found_nearest_neighbors.peek().unwrap().0
+                    {
+                        candidates.push(Reverse((score, *neighbor as usize)));
+                        currently_found_nearest_neighbors.push((score, *neighbor as usize));
+                        if currently_found_nearest_neighbors.len() > ef {
+                            currently_found_nearest_neighbors.pop(); // evict the farthest
                         }
+                    }
                 }
             }
         }
@@ -545,7 +571,7 @@ where
     ) -> Vec<(usize, u32)> {
         let mut candidates: BinaryHeap<Reverse<(u32, usize)>> = BinaryHeap::with_capacity(ef); // Min heap
         candidates.push(Reverse((score, enter_point)));
-        let mut currently_found_nearest_neighbors: BinaryHeap<(u32, usize)> = 
+        let mut currently_found_nearest_neighbors: BinaryHeap<(u32, usize)> =
             BinaryHeap::with_capacity(ef + 1); // Max heap
         currently_found_nearest_neighbors.push((score, enter_point));
 

--- a/src/datalayer/algorithms.rs
+++ b/src/datalayer/algorithms.rs
@@ -16,7 +16,7 @@ impl DistanceAlgorithm<u32> for NormalDistance {
 pub struct TlshDistance;
 impl DistanceAlgorithm<TlshDefault> for TlshDistance {
     fn calculate_distance(&self, a: &TlshDefault, b: &TlshDefault) -> u32 {
-        let diff = a.diff(&b, true);
+        let diff = a.diff(b, true);
         diff as u32
     }
 }

--- a/src/datalayer/record.rs
+++ b/src/datalayer/record.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use tlsh2::{TlshDefault};
+use tlsh2::TlshDefault;
 
 /// Trait for Metric types (like TLSH or numerical IDs) to specify if they natively map to a Radix Tree exact-match key.
 pub trait RadixKeyMapping {


### PR DESCRIPTION
## Summary

The CI workflow was left over from an earlier Python version of the project (sets up Python 3.9, runs unittest) and did not build, test or lint any Rust code. It also did not trigger on the apotheosis2 branch.

## Changes

- `cargo fmt` applied to hnsw.rs and record.rs (mechanical, no logic changes) and every clippy warning fixed across `src/`, verified one by one (details in individual commits). Both were prerequisites: a fmt/clippy CI job added on top of unformatted or warning-producing code would fail on day one.
- `Cargo.toml`: added `rust-version = "1.88"`, the version that stabilizes let-chains, used by some of the clippy fixes.
- `.github/workflows/ci.yml`: replaced with a Rust pipeline (fmt, clippy, test, release build, cargo-deny, cross-platform check, typos, MSRV, docs), triggered on the `apotheosis2` branch.
- `deny.toml`: license and advisory policy for `cargo-deny`.
- `_typos.toml`: exceptions for the two Spanish words in README's Funding support section (`Estratégicos`, `Ciberseguridad`), which the English dictionary would otherwise flag.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, `cargo build --release --all-features` and `cargo doc --no-deps --all-features` (with `RUSTDOCFLAGS=-D warnings`) all pass locally.
- [ ] `cargo-deny` and `typos-cli` could not be installed locally (unrelated toolchain issue); not verified locally, will be validated by the CI run itself on this PR.

Closes #19