### PR TITLE
test: add integration test suite (closes #21)

### DIFF
--- a/tests/ann_correctness.rs
+++ b/tests/ann_correctness.rs
@@ -23,8 +23,10 @@ type ApoNumHeuristic = Apotheosis<SimpleNumberRecord, NormalDistance, 16, 32, 40
 // (random_level() with M=16 puts ~6% of inserts above layer 0; seed is fixed
 // at 42 in default_rng(), so this is deterministic, not flaky).
 //
-// Query 301 is not in the dataset (odd, mid-range) so search() takes the ANN
-// path (knn_search), not the radix fast-path.
+// Queries are odd values (not in the even-valued dataset), so search() takes
+// the ANN path (knn_search), not the radix fast-path. Mean recall over many
+// queries with a strict threshold: a single lucky query would not catch a
+// quality regression, and on 1-D data HNSW should be near-exact.
 // ---------------------------------------------------------------------------
 #[test]
 fn ann_recall_matches_brute_force() {
@@ -36,36 +38,42 @@ fn ann_recall_matches_brute_force() {
         inserted.push(value);
     }
 
-    let query = 301u32;
     let k = 10;
+    // 40 odd queries spread across and slightly beyond the dataset range.
+    let queries: Vec<u32> = (0..40u32).map(|q| q * 15 + 1).collect();
 
-    let ann_results = idx.search(&query, k, Some(400));
-    let ann_values: HashSet<u32> = ann_results.iter().map(|(_, r)| r.search_id()).collect();
+    let mut total_recall = 0.0;
+    for query in &queries {
+        let ann_results = idx.search(query, k, Some(400));
+        let ann_values: HashSet<u32> = ann_results.iter().map(|(_, r)| r.search_id()).collect();
 
-    let mut brute: Vec<(u32, u32)> = inserted.iter().map(|&v| (v.abs_diff(query), v)).collect();
-    brute.sort_by_key(|&(d, _)| d);
-    let brute_values: HashSet<u32> = brute.iter().take(k).map(|&(_, v)| v).collect();
+        let mut brute: Vec<(u32, u32)> =
+            inserted.iter().map(|&v| (v.abs_diff(*query), v)).collect();
+        brute.sort_by_key(|&(d, _)| d);
+        let brute_values: HashSet<u32> = brute.iter().take(k).map(|&(_, v)| v).collect();
 
-    let recall = ann_values.intersection(&brute_values).count() as f64 / k as f64;
+        total_recall += ann_values.intersection(&brute_values).count() as f64 / k as f64;
+
+        // The nearest neighbor must always be exact (catches gross errors,
+        // e.g. wrong layer/index resolution returning unrelated neighbors).
+        let brute_min_distance = brute[0].0;
+        let ann_min_distance = ann_results
+            .iter()
+            .map(|(d, _)| *d)
+            .min()
+            .expect("ANN must return at least one result for a non-empty index");
+        assert_eq!(
+            ann_min_distance, brute_min_distance,
+            "ANN closest distance must match brute-force for query {query}"
+        );
+    }
+
+    let mean_recall = total_recall / queries.len() as f64;
     assert!(
-        recall >= 0.7,
-        "ANN recall too low: {:.2} (ann={:?}, brute_top10={:?})",
-        recall,
-        ann_values,
-        brute_values
-    );
-
-    // distance-0 sanity for the closest known points (catches gross errors,
-    // e.g. wrong layer/index resolution returning unrelated neighbors)
-    let brute_min_distance = brute[0].0;
-    let ann_min_distance = ann_results
-        .iter()
-        .map(|(d, _)| *d)
-        .min()
-        .expect("ANN must return at least one result for a non-empty index");
-    assert_eq!(
-        ann_min_distance, brute_min_distance,
-        "ANN closest distance must match brute-force closest distance"
+        mean_recall >= 0.9,
+        "mean ANN recall over {} queries too low: {:.3}",
+        queries.len(),
+        mean_recall
     );
 }
 

--- a/tests/ann_correctness.rs
+++ b/tests/ann_correctness.rs
@@ -1,0 +1,175 @@
+// ANN correctness tests for APOTHEOSIS 2
+//
+// A failing test here means the ANN graph returns wrong neighbors, not just
+// that an API contract or invariant is violated.
+
+use apotheosis2::controllers::apotheosis::Apotheosis;
+use apotheosis2::datalayer::algorithms::NormalDistance;
+use apotheosis2::datalayer::record::{ApotheosisRecord, SimpleNumberRecord};
+use std::collections::HashSet;
+
+type ApoNum = Apotheosis<SimpleNumberRecord, NormalDistance>;
+type ApoNumHeuristic = Apotheosis<SimpleNumberRecord, NormalDistance, 16, 32, 400, true>;
+
+// ---------------------------------------------------------------------------
+// Test - ann_recall_matches_brute_force
+//
+// Invariant: the ANN path (knn_search) must agree with brute-force k-NN to a
+// reasonable recall. This is the actual correctness property of the library;
+// existing tests only check that search() doesn't crash and returns sorted,
+// bounded-length results - never that the results are *right*.
+//
+// 300 records (even values 0..600 step 2) force multiple HNSW layers
+// (random_level() with M=16 puts ~6% of inserts above layer 0; seed is fixed
+// at 42 in default_rng(), so this is deterministic, not flaky).
+//
+// Query 301 is not in the dataset (odd, mid-range) so search() takes the ANN
+// path (knn_search), not the radix fast-path.
+// ---------------------------------------------------------------------------
+#[test]
+fn ann_recall_matches_brute_force() {
+    let mut idx = ApoNum::new();
+    let mut inserted = vec![];
+    for i in 0..300u32 {
+        let value = i * 2;
+        idx.insert(SimpleNumberRecord::create(value.to_string()));
+        inserted.push(value);
+    }
+
+    let query = 301u32;
+    let k = 10;
+
+    let ann_results = idx.search(&query, k, Some(400));
+    let ann_values: HashSet<u32> = ann_results.iter().map(|(_, r)| r.search_id()).collect();
+
+    let mut brute: Vec<(u32, u32)> = inserted.iter().map(|&v| (v.abs_diff(query), v)).collect();
+    brute.sort_by_key(|&(d, _)| d);
+    let brute_values: HashSet<u32> = brute.iter().take(k).map(|&(_, v)| v).collect();
+
+    let recall = ann_values.intersection(&brute_values).count() as f64 / k as f64;
+    assert!(
+        recall >= 0.7,
+        "ANN recall too low: {:.2} (ann={:?}, brute_top10={:?})",
+        recall,
+        ann_values,
+        brute_values
+    );
+
+    // distance-0 sanity for the closest known points (catches gross errors,
+    // e.g. wrong layer/index resolution returning unrelated neighbors)
+    let brute_min_distance = brute[0].0;
+    let ann_min_distance = ann_results
+        .iter()
+        .map(|(d, _)| *d)
+        .min()
+        .expect("ANN must return at least one result for a non-empty index");
+    assert_eq!(
+        ann_min_distance, brute_min_distance,
+        "ANN closest distance must match brute-force closest distance"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test - multi_layer_search_correct_across_layers
+//
+// zero_layer neighbors are feature indices; upper_layer neighbors are
+// in-layer node indices. This asymmetry is load-bearing: a bug there would
+// go undetected by tests using small datasets (10-20 records) that may never
+// produce upper layers. 300 records guarantees multiple layers.
+//
+// First assert that the dataset actually produced upper layers; if it
+// didn't, the test below would pass vacuously and prove nothing.
+// ---------------------------------------------------------------------------
+#[test]
+fn multi_layer_search_correct_across_layers() {
+    let mut idx = ApoNum::new();
+    let mut inserted = vec![];
+    for i in 0..300u32 {
+        let value = i * 3;
+        idx.insert(SimpleNumberRecord::create(value.to_string()));
+        inserted.push(value);
+    }
+
+    let layer_count = idx.hnsw.draw_model().len();
+    assert!(
+        layer_count > 1,
+        "dataset must produce upper layers to exercise the zero/upper index asymmetry, got {layer_count} layer(s)"
+    );
+
+    // Exact match (fast-path, bypasses traversal entirely) must still resolve
+    // correctly regardless of how many upper layers exist.
+    let exact = idx.search(&150u32, 1, None);
+    assert!(
+        !exact.is_empty(),
+        "exact match for key 150 must return a result"
+    );
+    assert_eq!(exact[0].0, 0, "exact match must have distance 0");
+
+    // ANN path must descend through upper layers correctly and land on the
+    // true nearest neighbor at layer 0.
+    let query = 301u32;
+    let k = 5;
+    let ann_results = idx.search(&query, k, Some(400));
+
+    let mut brute: Vec<u32> = inserted.iter().map(|&v| v.abs_diff(query)).collect();
+    brute.sort();
+
+    let ann_min = ann_results
+        .iter()
+        .map(|(d, _)| *d)
+        .min()
+        .expect("ANN must return at least one result for a non-empty index");
+    assert_eq!(
+        ann_min, brute[0],
+        "ANN closest distance across multi-layer graph must match brute-force"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test - heuristic_produces_different_graph_than_greedy
+//
+// Confirms that HEURISTIC=true actually activates a different neighbor
+// selection branch (add_node_heuristic vs add_node) and produces a
+// structurally distinct zero_layer graph.
+//
+// The heuristic selection algorithm (select_neighbors_heuristic) applies a
+// diversity criterion: candidate C is only added if it is closer to the
+// new node than to any already-selected neighbor. For 1D sequential data
+// this produces sparser, more "local" connections than greedy - for an
+// interior node (e.g. 30) greedy picks up to M0 neighbors in both directions
+// while heuristic quickly saturates with the two nearest and skips further
+// nodes whose closest already-selected neighbor is nearer than the new node.
+//
+// The test compares zero_layer edge multisets (sorted node-pair strings from
+// draw_model()[0].1). If the graphs were identical, HEURISTIC=true would be
+// dead code and config tests with that flag would be false positives.
+// ---------------------------------------------------------------------------
+#[test]
+fn heuristic_produces_different_graph_than_greedy() {
+    let n = 50u32;
+
+    let mut greedy = ApoNum::new();
+    let mut heuristic = ApoNumHeuristic::new();
+
+    for i in 0..n {
+        greedy.insert(SimpleNumberRecord::create(i.to_string())); // safe: sequential, unique
+        heuristic.insert(SimpleNumberRecord::create(i.to_string())); // safe: sequential, unique
+    }
+
+    // Collect edge sets as sorted (src, dst) string pairs - direction-agnostic.
+    let edges_for = |edges: Vec<(String, String, f32)>| -> HashSet<(String, String)> {
+        edges
+            .into_iter()
+            .map(|(a, b, _)| if a <= b { (a, b) } else { (b, a) })
+            .collect()
+    };
+
+    let greedy_edges = edges_for(greedy.hnsw.draw_model()[0].1.clone());
+    let heuristic_edges = edges_for(heuristic.hnsw.draw_model()[0].1.clone());
+
+    assert_ne!(
+        greedy_edges, heuristic_edges,
+        "HEURISTIC=true must produce a different zero_layer graph than HEURISTIC=false \
+         (if equal, add_node_heuristic is not diverging from add_node for this dataset)"
+    );
+}

--- a/tests/api_contract.rs
+++ b/tests/api_contract.rs
@@ -1,18 +1,239 @@
+// API contract tests for APOTHEOSIS 2
+//
+// A failing test here means a public operation violates its observable
+// behavioral contract as seen by an external caller.
+
 use apotheosis2::controllers::apotheosis::Apotheosis;
 use apotheosis2::datalayer::algorithms::NormalDistance;
 use apotheosis2::datalayer::record::SimpleNumberRecord;
 
 type ApoNum = Apotheosis<SimpleNumberRecord, NormalDistance>;
 
-// search() over an empty index must return an empty Vec without panicking.
-// Before the fix (issue #8), knn_search() accessed zero_layer[0] without
-// checking whether the slice was empty, causing a panic.
+// ---------------------------------------------------------------------------
+// Test 1 - search_ann_path_returns_k_or_fewer_sorted_by_distance
+//
+// Contract: search() on the ANN path returns at most k results sorted by
+// distance ascending. Querying a missing key (9999) forces a radix miss
+// and invokes knn_search().
+// ---------------------------------------------------------------------------
 #[test]
-fn search_on_empty_index_returns_empty_vec() {
+fn search_ann_path_returns_k_or_fewer_sorted_by_distance() {
+    let mut idx = ApoNum::new();
+    for i in 0..20u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+
+    let k = 5;
+    let results = idx.search(&9999u32, k, None);
+
+    assert!(
+        results.len() <= k,
+        "search() must return at most k={} results, got {}",
+        k,
+        results.len()
+    );
+
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {:?} > {:?}", w[0], w[1]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 - search_on_empty_system_returns_empty_vec
+//
+// Contract: search() on an empty Apotheosis returns an empty Vec.
+// ---------------------------------------------------------------------------
+#[test]
+fn search_on_empty_system_returns_empty_vec() {
     let idx = ApoNum::new();
     let results = idx.search(&0u32, 1, None);
     assert!(
         results.is_empty(),
-        "search() over an empty index must return an empty Vec"
+        "search() on empty index must return empty Vec"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 - draw_produces_one_gexf_file_per_layer
+//
+// Contract: draw(base_path) creates exactly one .gexf file per HNSW layer,
+// named <stem>_layer<N>.gexf for N in 0..L where L = draw_model().len().
+// No extra files beyond layer L-1 may exist.
+// ---------------------------------------------------------------------------
+#[test]
+fn draw_produces_one_gexf_file_per_layer() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let dir = "target/test_draw_gexf";
+    let base = format!("{}/model", dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let mut idx = ApoNum::new();
+    for i in 0..200u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+
+    let layer_count = idx.hnsw.draw_model().len();
+    idx.draw(&base);
+
+    for n in 0..layer_count {
+        let f = PathBuf::from(format!("{}/model_layer{}.gexf", dir, n));
+        assert!(f.exists(), "draw() must produce {:?} for layer {}", f, n);
+    }
+
+    let extra = PathBuf::from(format!("{}/model_layer{}.gexf", dir, layer_count));
+    assert!(
+        !extra.exists(),
+        "draw() must not produce a file for layer {} (only {} layers exist)",
+        layer_count,
+        layer_count
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 - load_overwrites_previous_in_memory_state
+//
+// Contract: load() replaces all in-memory state with the deserialized model.
+// Data present before load() must not be reachable afterwards; data from the
+// loaded model must be.
+// ---------------------------------------------------------------------------
+#[test]
+fn load_overwrites_previous_in_memory_state() {
+    use apotheosis2::datalayer::record::ApotheosisRecord;
+    use std::fs;
+
+    let path = "target/test_load_overwrite.bin";
+
+    let mut idx_a = ApoNum::new();
+    for i in 0..5u32 {
+        idx_a.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+    idx_a.dump(path).expect("dump() must not fail");
+
+    let mut idx_b = ApoNum::new();
+    for i in 100..103u32 {
+        idx_b.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+    idx_b = ApoNum::load(path).expect("load() must not fail");
+
+    assert!(
+        !idx_b.search(&2u32, 1, None).is_empty(),
+        "after load(), loaded data (key 2) must be reachable"
+    );
+
+    let has_stale = idx_b
+        .search(&100u32, 5, None)
+        .iter()
+        .any(|(_, r)| r.search_id() == 100u32);
+    assert!(
+        !has_stale,
+        "after load(), pre-load data (key 100) must be gone"
+    );
+
+    fs::remove_file(path).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 - load_rejects_corrupt_magic_bytes
+//
+// Contract: load() must return Err (not panic) when the file does not start
+// with the expected "APOT" magic bytes.
+// ---------------------------------------------------------------------------
+#[test]
+fn load_rejects_corrupt_magic_bytes() {
+    use std::fs;
+
+    let path = "target/test_corrupt_magic.bin";
+    // Write a full 17-byte header with wrong magic bytes but otherwise plausible
+    // content, so the magic check (not a short read) is what rejects the file.
+    fs::write(
+        path,
+        b"NOPE\x10\x00\x00\x00\x20\x00\x00\x00\x90\x01\x00\x00\x00",
+    )
+    .unwrap(); // safe: simple fs write
+
+    let result = ApoNum::load(path);
+    fs::remove_file(path).ok();
+
+    assert!(
+        result.is_err(),
+        "load() must return Err on invalid magic bytes"
+    );
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("magic") || msg.contains("Invalid"),
+        "error message must mention invalid file, got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 - load_rejects_truncated_file
+//
+// Contract: load() must return Err (not panic) when the file is shorter than
+// the 17-byte header it expects.
+// ---------------------------------------------------------------------------
+#[test]
+fn load_rejects_truncated_file() {
+    use std::fs;
+
+    let path = "target/test_truncated.bin";
+    fs::write(path, b"APOT\x10\x00").unwrap(); // safe: 6 bytes - shorter than 17-byte header
+
+    let result = ApoNum::load(path);
+    fs::remove_file(path).ok();
+
+    assert!(
+        result.is_err(),
+        "load() must return Err on truncated header"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 - search_with_k_zero_returns_empty
+//
+// Contract: search() with k=0 must return an empty Vec without panicking.
+// Query not in dataset forces the ANN path; .take(0) returns empty.
+// ---------------------------------------------------------------------------
+#[test]
+fn search_with_k_zero_returns_empty() {
+    let mut idx = ApoNum::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: unique keys
+    }
+    // Query not in dataset → ANN path → .take(0) → empty Vec.
+    let results = idx.search(&9999u32, 0, None);
+    assert!(
+        results.is_empty(),
+        "search() with k=0 must return empty Vec, got {} results",
+        results.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8 - search_with_k_greater_than_n_returns_all
+//
+// Contract: search() with k > records.len() must return at most records.len()
+// results without panicking. Requesting more neighbors than exist is valid.
+// ---------------------------------------------------------------------------
+#[test]
+fn search_with_k_greater_than_n_returns_all() {
+    let mut idx = ApoNum::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: unique keys
+    }
+    let k = 100; // far larger than the 10 records
+    let results = idx.search(&9999u32, k, None);
+    assert!(
+        results.len() <= 10,
+        "search() with k={k} on 10 records must return at most 10, got {}",
+        results.len()
+    );
+    assert!(
+        !results.is_empty(),
+        "search() with k={k} on non-empty index must return something"
     );
 }

--- a/tests/config_boundary.rs
+++ b/tests/config_boundary.rs
@@ -31,6 +31,10 @@ type ApoDense = Apotheosis<SimpleNumberRecord, NormalDistance, 64, 128, 1000>;
 // Default alias reused for runtime-parameter edge cases (ef_search, k).
 type ApoDefault = Apotheosis<SimpleNumberRecord, NormalDistance>;
 
+// Small neighbor lists (M=4, M0=8) for the saturation/eviction test: with a
+// dataset far larger than M0, every list fills and the eviction branch runs.
+type ApoNumSmallSat = Apotheosis<SimpleNumberRecord, NormalDistance, 4, 8, 100>;
+
 // ---------------------------------------------------------------------------
 // Sync invariant × 4 boundary configs
 //
@@ -218,4 +222,46 @@ fn search_k_greater_than_ef_search() {
     for w in distances.windows(2) {
         assert!(w[0] <= w[1], "results not sorted: {} > {}", w[0], w[1]);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Neighbor-list saturation: dataset much larger than M0
+//
+// With 10-record datasets and M0=32 the neighbor lists never fill up, so the
+// replacement branch in connect_neighbors (list full: evict the farthest
+// neighbor) never runs. 300 records with M0=8 saturate every list many times
+// over, exercising eviction continuously. The graph must stay consistent:
+// exact-match works for every key and ANN search still finds true nearest.
+// ---------------------------------------------------------------------------
+#[test]
+fn eviction_under_saturation_keeps_graph_consistent() {
+    use apotheosis2::datalayer::record::ApotheosisRecord;
+
+    // M=4, M0=8: every node's list overflows repeatedly with 300 inserts.
+    let mut idx = ApoNumSmallSat::new();
+    let n = 300u32;
+    for i in 0..n {
+        idx.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+
+    // Every key must still resolve exactly through the radix fast-path.
+    for key in (0..n).step_by(7) {
+        let results = idx.search(&key, 1, None);
+        assert!(
+            !results.is_empty(),
+            "exact search for key {key} returned nothing"
+        );
+        assert_eq!(
+            results[0].0, 0,
+            "exact match for key {key} must have distance 0"
+        );
+        assert_eq!(results[0].1.search_id(), key, "wrong record for key {key}");
+    }
+
+    // ANN path (query not in dataset) must still find the true nearest.
+    let results = idx.search(&1000u32, 5, Some(100));
+    assert!(!results.is_empty(), "ANN search returned nothing");
+    let min = results.iter().map(|(d, _)| *d).min().unwrap();
+    // True nearest to 1000 is 299, distance 701.
+    assert_eq!(min, 701, "ANN nearest after heavy eviction must be exact");
 }

--- a/tests/config_boundary.rs
+++ b/tests/config_boundary.rs
@@ -1,0 +1,221 @@
+// Boundary and stress configuration tests for APOTHEOSIS 2
+//
+// Probes structural limits: minimum viable parameters, inverted ratios,
+// degenerate EF values, and runtime mismatches between k and ef_search.
+//
+// WHY M=2 AND NOT M=1
+// -------------------
+// M=1 causes OOM/hang on the first insert, not a catchable panic.
+// random_level() computes -ln(u)/ln(M). With M=1, ln(1)=0 → f64::INFINITY
+// → as usize = usize::MAX. initialize() then loops usize::MAX iterations.
+// M=2 is the minimum viable value: ln(2) ≈ 0.693 → finite level values.
+
+use apotheosis2::controllers::apotheosis::Apotheosis;
+use apotheosis2::datalayer::algorithms::NormalDistance;
+use apotheosis2::datalayer::record::SimpleNumberRecord;
+
+// M=2 (minimum viable, see note above), M0=4, EF=1 (absolute minimum exploration).
+// Graph built with near-zero exploration - structurally valid, low quality by design.
+type ApoMinViable = Apotheosis<SimpleNumberRecord, NormalDistance, 2, 4, 1>;
+
+// M > M0 (inverted standard ratio - normally M0 = 2×M per HNSW convention).
+// Upper layers denser than zero_layer. No code path enforces M <= M0.
+type ApoInverted = Apotheosis<SimpleNumberRecord, NormalDistance, 32, 8, 400>;
+
+// M == M0 (no asymmetry between layers).
+type ApoEqualMM0 = Apotheosis<SimpleNumberRecord, NormalDistance, 8, 8, 200>;
+
+// Maximum connectivity - near brute-force for small datasets.
+type ApoDense = Apotheosis<SimpleNumberRecord, NormalDistance, 64, 128, 1000>;
+
+// Default alias reused for runtime-parameter edge cases (ef_search, k).
+type ApoDefault = Apotheosis<SimpleNumberRecord, NormalDistance>;
+
+// ---------------------------------------------------------------------------
+// Sync invariant × 4 boundary configs
+//
+// For degenerate configs the sync invariant must hold regardless of graph
+// quality - records.len() == zero_layer node count after N inserts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sync_invariant_min_viable() {
+    let mut idx = ApoMinViable::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let zero_len = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(idx.records.len(), 10);
+    assert_eq!(zero_len, 10);
+    assert_eq!(idx.records.len(), zero_len);
+}
+
+#[test]
+fn sync_invariant_inverted_ratio() {
+    let mut idx = ApoInverted::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let zero_len = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(idx.records.len(), 10);
+    assert_eq!(zero_len, 10);
+    assert_eq!(idx.records.len(), zero_len);
+}
+
+#[test]
+fn sync_invariant_equal_m_m0() {
+    let mut idx = ApoEqualMM0::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let zero_len = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(idx.records.len(), 10);
+    assert_eq!(zero_len, 10);
+    assert_eq!(idx.records.len(), zero_len);
+}
+
+#[test]
+fn sync_invariant_dense() {
+    let mut idx = ApoDense::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let zero_len = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(idx.records.len(), 10);
+    assert_eq!(zero_len, 10);
+    assert_eq!(idx.records.len(), zero_len);
+}
+
+// ---------------------------------------------------------------------------
+// No-panic search × 4 boundary configs
+//
+// These configs are not expected to yield high-quality ANN results (especially
+// ApoMinViable with EF=1 construction). The contract here is weaker: search()
+// must not panic and must return at most k results sorted ascending.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_no_panic_min_viable() {
+    let mut idx = ApoMinViable::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let k = 3;
+    // Query not in dataset → ANN path. ef_search=None → unwrap_or(24) inside search().
+    let results = idx.search(&9999u32, k, None);
+    assert!(
+        results.len() <= k,
+        "must return at most k={k}, got {}",
+        results.len()
+    );
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {} > {}", w[0], w[1]);
+    }
+}
+
+#[test]
+fn search_no_panic_inverted_ratio() {
+    let mut idx = ApoInverted::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let k = 3;
+    let results = idx.search(&9999u32, k, None);
+    assert!(
+        results.len() <= k,
+        "must return at most k={k}, got {}",
+        results.len()
+    );
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {} > {}", w[0], w[1]);
+    }
+}
+
+#[test]
+fn search_no_panic_equal_m_m0() {
+    let mut idx = ApoEqualMM0::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let k = 3;
+    let results = idx.search(&9999u32, k, None);
+    assert!(
+        results.len() <= k,
+        "must return at most k={k}, got {}",
+        results.len()
+    );
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {} > {}", w[0], w[1]);
+    }
+}
+
+#[test]
+fn search_no_panic_dense() {
+    let mut idx = ApoDense::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let k = 3;
+    let results = idx.search(&9999u32, k, None);
+    assert!(
+        results.len() <= k,
+        "must return at most k={k}, got {}",
+        results.len()
+    );
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {} > {}", w[0], w[1]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime edge cases - parametric, reuse ApoDefault
+//
+// These test the ef_search and k runtime parameters, not the compile-time
+// const-generics. ApoDefault (M=16, M0=32, EF=400) is the vehicle.
+// ---------------------------------------------------------------------------
+
+// ef_search=Some(1000) with only 10 records in the index.
+// search_layer_zero exhausts all candidates before reaching ef; must not panic.
+#[test]
+fn search_ef_search_greater_than_n() {
+    let mut idx = ApoDefault::new();
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let k = 5;
+    let results = idx.search(&9999u32, k, Some(1000));
+    assert!(
+        results.len() <= k,
+        "must return at most k={k}, got {}",
+        results.len()
+    );
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {} > {}", w[0], w[1]);
+    }
+}
+
+// k=10 > ef_search=2. knn_search explores only 2 candidates, returns ≤2,
+// then .take(10) takes what's there. Must not panic; result ≤ k.
+#[test]
+fn search_k_greater_than_ef_search() {
+    let mut idx = ApoDefault::new();
+    for i in 0..20u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string())); // safe: keys are unique
+    }
+    let k = 10;
+    let results = idx.search(&9999u32, k, Some(2));
+    assert!(
+        results.len() <= k,
+        "must return at most k={k}, got {}",
+        results.len()
+    );
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {} > {}", w[0], w[1]);
+    }
+}

--- a/tests/config_matrix.rs
+++ b/tests/config_matrix.rs
@@ -1,0 +1,346 @@
+// Configuration matrix tests for APOTHEOSIS 2
+//
+// Verifies that fitness functions and API contracts hold across different
+// compile-time configurations (M, M0, EF, HEURISTIC).
+
+use apotheosis2::controllers::apotheosis::Apotheosis;
+use apotheosis2::datalayer::algorithms::NormalDistance;
+use apotheosis2::datalayer::record::SimpleNumberRecord;
+
+// Default configuration (M=16, M0=32, EF=400, HEURISTIC=false).
+type ApoNumDefault = Apotheosis<SimpleNumberRecord, NormalDistance>;
+
+// Sparse graph - M=4, M0=8 reduce connectivity; EF=50 reduces search breadth.
+// Exercises the HNSW code paths under low-connectivity conditions.
+type ApoNumSmall = Apotheosis<SimpleNumberRecord, NormalDistance, 4, 8, 50>;
+
+// Heuristic neighbor selection - HEURISTIC=true activates the alternate branch
+// in insert(). Same M/M0/EF as default so only the selection algorithm differs.
+type ApoNumHeuristic = Apotheosis<SimpleNumberRecord, NormalDistance, 16, 32, 400, true>;
+
+// Deterministic dataset of 10 records (keys 0..10), identical for all configs.
+fn build_dataset_default() -> ApoNumDefault {
+    let mut idx = ApoNumDefault::new();
+    for i in 0..10u32 {
+        assert!(
+            idx.insert(SimpleNumberRecord::create(i.to_string())),
+            "insert unexpectedly returned false for key {i}"
+        );
+    }
+    idx
+}
+
+fn build_dataset_small() -> ApoNumSmall {
+    let mut idx = ApoNumSmall::new();
+    for i in 0..10u32 {
+        assert!(
+            idx.insert(SimpleNumberRecord::create(i.to_string())),
+            "insert unexpectedly returned false for key {i}"
+        );
+    }
+    idx
+}
+
+fn build_dataset_heuristic() -> ApoNumHeuristic {
+    let mut idx = ApoNumHeuristic::new();
+    for i in 0..10u32 {
+        assert!(
+            idx.insert(SimpleNumberRecord::create(i.to_string())),
+            "insert unexpectedly returned false for key {i}"
+        );
+    }
+    idx
+}
+
+// ---------------------------------------------------------------------------
+// FF1 - sync_invariant: records.len() == zero_layer node count after 10 inserts
+//
+// draw_model()[0].0.len() is the proxy for zero_layer node count.
+// draw_model() is pub on Hnsw; [0] is always zero_layer (pushed first,
+// unconditionally). .0 is Vec<usize> of feature indices - independent of M0.
+//
+// Full radix traversal (every key maps to a valid index) is not covered here
+// because RadixNode exposes no public iterator; that constraint is enforced
+// structurally by insert() being the sole mutation point.
+// ---------------------------------------------------------------------------
+#[test]
+fn ff1_sync_invariant_default() {
+    let idx = build_dataset_default();
+    let zero_layer_count = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(idx.records.len(), 10, "records must contain 10 entries");
+    assert_eq!(zero_layer_count, 10, "zero_layer must contain 10 nodes");
+    assert_eq!(
+        idx.records.len(),
+        zero_layer_count,
+        "records and zero_layer diverged"
+    );
+}
+
+#[test]
+fn ff1_sync_invariant_small() {
+    let idx = build_dataset_small();
+    let zero_layer_count = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(idx.records.len(), 10, "records must contain 10 entries");
+    assert_eq!(zero_layer_count, 10, "zero_layer must contain 10 nodes");
+    assert_eq!(
+        idx.records.len(),
+        zero_layer_count,
+        "records and zero_layer diverged"
+    );
+}
+
+#[test]
+fn ff1_sync_invariant_heuristic() {
+    let idx = build_dataset_heuristic();
+    let zero_layer_count = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(idx.records.len(), 10, "records must contain 10 entries");
+    assert_eq!(zero_layer_count, 10, "zero_layer must contain 10 nodes");
+    assert_eq!(
+        idx.records.len(),
+        zero_layer_count,
+        "records and zero_layer diverged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FF4 - exact_match: searching an inserted key returns it with distance 0
+//
+// Key 5 is in the dataset → radix hit → fast-path → first result distance 0.
+// ---------------------------------------------------------------------------
+#[test]
+fn ff4_exact_match_default() {
+    let idx = build_dataset_default();
+    let results = idx.search(&5u32, 1, None);
+    assert!(
+        !results.is_empty(),
+        "search for inserted key 5 must return a result"
+    );
+    assert_eq!(results[0].0, 0, "exact match must have distance 0");
+}
+
+#[test]
+fn ff4_exact_match_small() {
+    let idx = build_dataset_small();
+    let results = idx.search(&5u32, 1, None);
+    assert!(
+        !results.is_empty(),
+        "search for inserted key 5 must return a result"
+    );
+    assert_eq!(results[0].0, 0, "exact match must have distance 0");
+}
+
+#[test]
+fn ff4_exact_match_heuristic() {
+    let idx = build_dataset_heuristic();
+    let results = idx.search(&5u32, 1, None);
+    assert!(
+        !results.is_empty(),
+        "search for inserted key 5 must return a result"
+    );
+    assert_eq!(results[0].0, 0, "exact match must have distance 0");
+}
+
+// ---------------------------------------------------------------------------
+// FF6 - roundtrip: dump+load produces identical search results
+//
+// Distinct paths per config to avoid race conditions when cargo test runs
+// integration tests in parallel.
+// ---------------------------------------------------------------------------
+#[test]
+fn ff6_roundtrip_default() {
+    use std::fs;
+
+    let path = "target/test_config_ff6_default.bin";
+    let idx = build_dataset_default();
+
+    let before: Vec<u32> = idx
+        .search(&7u32, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    idx.dump(path).expect("dump() must not fail");
+    let loaded = ApoNumDefault::load(path).expect("load() must not fail");
+
+    let after: Vec<u32> = loaded
+        .search(&7u32, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    fs::remove_file(path).ok();
+    assert_eq!(
+        before, after,
+        "search results must be identical after roundtrip"
+    );
+}
+
+#[test]
+fn ff6_roundtrip_small() {
+    use std::fs;
+
+    let path = "target/test_config_ff6_small.bin";
+    let idx = build_dataset_small();
+
+    let before: Vec<u32> = idx
+        .search(&7u32, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    idx.dump(path).expect("dump() must not fail");
+    let loaded = ApoNumSmall::load(path).expect("load() must not fail");
+
+    let after: Vec<u32> = loaded
+        .search(&7u32, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    fs::remove_file(path).ok();
+    assert_eq!(
+        before, after,
+        "search results must be identical after roundtrip"
+    );
+}
+
+#[test]
+fn ff6_roundtrip_heuristic() {
+    use std::fs;
+
+    let path = "target/test_config_ff6_heuristic.bin";
+    let idx = build_dataset_heuristic();
+
+    let before: Vec<u32> = idx
+        .search(&7u32, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    idx.dump(path).expect("dump() must not fail");
+    // HEURISTIC is encoded in the header and validated by load(), so the
+    // loading type must match the dumping one (ApoNumHeuristic here).
+    let loaded = ApoNumHeuristic::load(path).expect("load() must not fail");
+
+    let after: Vec<u32> = loaded
+        .search(&7u32, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    fs::remove_file(path).ok();
+    assert_eq!(
+        before, after,
+        "search results must be identical after roundtrip"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC1 - ann_ordered: ANN path returns ≤k results sorted by distance ascending
+//
+// Key 9999 is not in the dataset → radix miss → knn_search() (ANN path).
+// ---------------------------------------------------------------------------
+#[test]
+fn ac1_ann_ordered_default() {
+    let idx = build_dataset_default();
+    let k = 3;
+    let results = idx.search(&9999u32, k, None);
+
+    assert!(
+        results.len() <= k,
+        "must return at most k={k} results, got {}",
+        results.len()
+    );
+
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {:?} > {:?}", w[0], w[1]);
+    }
+}
+
+#[test]
+fn ac1_ann_ordered_small() {
+    let idx = build_dataset_small();
+    let k = 3;
+    let results = idx.search(&9999u32, k, None);
+
+    assert!(
+        results.len() <= k,
+        "must return at most k={k} results, got {}",
+        results.len()
+    );
+
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {:?} > {:?}", w[0], w[1]);
+    }
+}
+
+#[test]
+fn ac1_ann_ordered_heuristic() {
+    let idx = build_dataset_heuristic();
+    let k = 3;
+    let results = idx.search(&9999u32, k, None);
+
+    assert!(
+        results.len() <= k,
+        "must return at most k={k} results, got {}",
+        results.len()
+    );
+
+    let distances: Vec<u32> = results.iter().map(|(d, _)| *d).collect();
+    for w in distances.windows(2) {
+        assert!(w[0] <= w[1], "results not sorted: {:?} > {:?}", w[0], w[1]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC - cross-config load: header validation rejects M/M0/EF mismatches
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac_cross_config_load_rejects_m_mismatch() {
+    let path = "target/test_config_cross_mismatch.bin";
+    let _ = std::fs::remove_file(path);
+
+    let idx = build_dataset_small(); // M=4, M0=8, EF=50
+    idx.dump(path).expect("dump() must not fail"); // safe: build_dataset_small() succeeded
+
+    let result = ApoNumDefault::load(path); // expects M=16, M0=32, EF=400
+
+    let _ = std::fs::remove_file(path);
+
+    assert!(result.is_err(), "load() must reject M/M0/EF mismatch");
+
+    // Exact format from apotheosis.rs load(): "Model parameter mismatch. File has M={m}, M0={m0}, EF={ef} but code expects M={M}, M0={M0}, EF={EF}"
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("M=4") && msg.contains("M=16"),
+        "error message must cite both file M=4 and expected M=16, got: {msg}"
+    );
+}
+
+// dump() encodes HEURISTIC as the 17th header byte and load() validates it
+// against the compile-time HEURISTIC of the loading type (issue #10).
+// A file built with HEURISTIC=true must not load into a HEURISTIC=false type.
+#[test]
+fn ac_cross_config_load_rejects_heuristic_mismatch() {
+    let path = "target/test_config_cross_heuristic.bin";
+    let _ = std::fs::remove_file(path);
+
+    let idx = build_dataset_heuristic(); // HEURISTIC=true, M=16, M0=32, EF=400
+    idx.dump(path).expect("dump() must not fail");
+
+    let result = ApoNumDefault::load(path); // HEURISTIC=false, same M/M0/EF
+
+    let _ = std::fs::remove_file(path);
+
+    assert!(result.is_err(), "load() must reject HEURISTIC mismatch");
+
+    // Exact format from apotheosis.rs load(): "Model parameter mismatch. File has HEURISTIC={} but code expects HEURISTIC={}"
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("HEURISTIC=true") && msg.contains("HEURISTIC=false"),
+        "error message must cite both file HEURISTIC=true and expected HEURISTIC=false, got: {msg}"
+    );
+}

--- a/tests/fitness_functions.rs
+++ b/tests/fitness_functions.rs
@@ -1,0 +1,229 @@
+// Fitness functions - architectural invariant tests for APOTHEOSIS 2
+//
+// A failing
+// test here means an architectural invariant is broken, not just a bug.
+
+use apotheosis2::controllers::apotheosis::Apotheosis;
+use apotheosis2::datalayer::algorithms::NormalDistance;
+use apotheosis2::datalayer::record::SimpleNumberRecord;
+
+// Convenience alias with default const generics (M=16, M0=32, EF=400, HEURISTIC=false)
+type ApoNum = Apotheosis<SimpleNumberRecord, NormalDistance>;
+
+// ---------------------------------------------------------------------------
+// Test 1 - sync_invariant_holds_after_bulk_insert
+//
+// Invariant: after N successful inserts of distinct keys, records.len()
+// and the HNSW element count must both equal N.
+//
+// The three parallel structures (records[], hnsw.features[], radix) must
+// stay in sync at all times. This is documented in:
+//   - docs/architecture/views/module/vista-modulos.md §7.2 (sync invariant)
+//   - docs/architecture/quality-attributes.md (correctness attribute)
+// ---------------------------------------------------------------------------
+#[test]
+fn sync_invariant_holds_after_bulk_insert() {
+    let mut idx = ApoNum::new();
+
+    for i in 0..50u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+
+    let hnsw_len = idx.hnsw.draw_model()[0].0.len();
+
+    assert_eq!(
+        idx.records.len(),
+        50,
+        "records[] should contain exactly 50 entries after 50 inserts"
+    );
+    assert_eq!(
+        hnsw_len, 50,
+        "HNSW zero_layer should contain exactly 50 nodes after 50 inserts"
+    );
+    assert_eq!(
+        idx.records.len(),
+        hnsw_len,
+        "records[] and HNSW must be in sync - parallel structures diverged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 - insert_returns_true_for_new_keys
+//
+// Invariant: insert() returns true when a new unique key is inserted.
+// A return value of false signals a duplicate rejection; true signals
+// successful indexing.
+//
+// Ref: docs/architecture/interfaz-apotheosis.md §2.1.2
+// ---------------------------------------------------------------------------
+#[test]
+fn insert_returns_true_for_new_keys() {
+    let mut idx = ApoNum::new();
+    let result = idx.insert(SimpleNumberRecord::create("1".to_string()));
+    assert!(result, "insert() must return true for a new unique key");
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 - insert_returns_false_for_duplicate_keys
+//
+// Invariant: insert() returns false when a key that already exists in the
+// radix tree is re-inserted, preventing duplicate entries.
+//
+// Ref: docs/architecture/interfaz-apotheosis.md §2.1.2
+//
+// NOTE: this test does NOT assert sync invariant after the duplicate insert.
+// Kept focused on the return-value contract only; sync state after rejection
+// is covered by sync_invariant_holds_after_duplicate_insert.
+// ---------------------------------------------------------------------------
+#[test]
+fn insert_returns_false_for_duplicate_keys() {
+    let mut idx = ApoNum::new();
+
+    let first = idx.insert(SimpleNumberRecord::create("42".to_string()));
+    assert!(first, "first insert of key '42' must return true");
+
+    let second = idx.insert(SimpleNumberRecord::create("42".to_string()));
+    assert!(!second, "duplicate insert of key '42' must return false");
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 - search_returns_exact_match_via_fast_path
+//
+// Invariant: searching for a key that was inserted returns that exact key
+// as the first result with distance 0, via the radix tree fast-path.
+//
+// When the query has a radix key and it exists in the tree, Apotheosis
+// calls get_neighbors_node() which pushes the matched node first with
+// distance 0. The ANN path is bypassed entirely.
+//
+// Ref: docs/architecture/views/cc/vista-cc.md (fast-path vs ANN path)
+//      docs/architecture/interfaz-apotheosis.md §2.1.3
+// ---------------------------------------------------------------------------
+#[test]
+fn search_returns_exact_match_via_fast_path() {
+    let mut idx = ApoNum::new();
+    idx.insert(SimpleNumberRecord::create("100".to_string()));
+
+    let query: u32 = 100;
+    let results = idx.search(&query, 1, None);
+
+    assert!(
+        !results.is_empty(),
+        "search() must return at least one result when the key exists"
+    );
+    assert_eq!(
+        results[0].0, 0,
+        "exact match via fast-path must have distance 0"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 - search_returns_k_or_fewer_results
+//
+// Invariant: search() never returns more than k results regardless of
+// how many records are in the model.
+//
+// Ref: docs/architecture/interfaz-apotheosis.md §2.1.3
+// ---------------------------------------------------------------------------
+#[test]
+fn search_returns_k_or_fewer_results() {
+    let mut idx = ApoNum::new();
+
+    for i in 0..10u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+
+    let query: u32 = 5;
+    let results = idx.search(&query, 3, None);
+
+    assert!(
+        results.len() <= 3,
+        "search() must return at most k=3 results, got {}",
+        results.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 - dump_load_roundtrip_preserves_search_results
+//
+// Invariant: a model serialized with dump() and reloaded with load()
+// produces identical search results for the same query.
+//
+// This protects the persistence integrity quality attribute: a stored
+// model must be bit-for-bit equivalent in behavior to the in-memory one.
+//
+// Ref: docs/architecture/quality-attributes.md (reproducibility)
+//      docs/architecture/interfaz-apotheosis.md §2.1.4, §2.1.5
+// ---------------------------------------------------------------------------
+#[test]
+fn dump_load_roundtrip_preserves_search_results() {
+    use std::fs;
+
+    let path = "target/test_roundtrip.bin";
+
+    let mut idx = ApoNum::new();
+    for i in 0..20u32 {
+        idx.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+
+    let query: u32 = 7;
+    let original_results: Vec<u32> = idx
+        .search(&query, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    idx.dump(path).expect("dump() must not fail");
+
+    let loaded = ApoNum::load(path).expect("load() must not fail");
+
+    let loaded_results: Vec<u32> = loaded
+        .search(&query, 3, Some(50))
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+
+    fs::remove_file(path).ok();
+
+    assert_eq!(
+        original_results, loaded_results,
+        "search results after load() must be identical to pre-dump results"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 - sync_invariant_holds_after_duplicate_insert
+//
+// Invariant: a duplicate insert (key already in radix tree) must return false
+// AND must not grow records[], hnsw.features[], or zero_layer.
+//
+// fitness_functions.rs::insert_returns_false_for_duplicate_keys (Test 3)
+// explicitly skips verifying sync state after the duplicate. This test closes
+// that gap: the three parallel structures must stay at len=1 after the dup.
+// ---------------------------------------------------------------------------
+#[test]
+fn sync_invariant_holds_after_duplicate_insert() {
+    let mut idx = ApoNum::new();
+
+    let first = idx.insert(SimpleNumberRecord::create("7".to_string()));
+    assert!(first, "first insert must return true");
+
+    let second = idx.insert(SimpleNumberRecord::create("7".to_string()));
+    assert!(!second, "duplicate insert must return false");
+
+    let zero_layer_count = idx.hnsw.draw_model()[0].0.len();
+    assert_eq!(
+        idx.records.len(),
+        1,
+        "records must not grow on duplicate insert"
+    );
+    assert_eq!(
+        zero_layer_count, 1,
+        "zero_layer must not grow on duplicate insert"
+    );
+    assert_eq!(
+        idx.records.len(),
+        zero_layer_count,
+        "records and zero_layer diverged after duplicate"
+    );
+}

--- a/tests/fitness_functions.rs
+++ b/tests/fitness_functions.rs
@@ -227,3 +227,41 @@ fn sync_invariant_holds_after_duplicate_insert() {
         "records and zero_layer diverged after duplicate"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test 8 - sync_invariant_maps_every_key_to_its_own_record
+//
+// Invariant: the shared index actually corresponds. The length-based sync
+// tests above pass even if entries are crossed (records[3] holding the data
+// of key 7). Exact-match search for every inserted key must return the
+// record that was inserted under that key, with distance 0.
+// ---------------------------------------------------------------------------
+#[test]
+fn sync_invariant_maps_every_key_to_its_own_record() {
+    use apotheosis2::datalayer::record::ApotheosisRecord;
+
+    let mut idx = ApoNum::new();
+    let n = 100u32;
+    for i in 0..n {
+        idx.insert(SimpleNumberRecord::create(i.to_string()));
+    }
+
+    for key in 0..n {
+        let results = idx.search(&key, 1, None);
+        assert!(
+            !results.is_empty(),
+            "exact search for key {key} returned nothing"
+        );
+        let (distance, record) = &results[0];
+        assert_eq!(
+            *distance, 0,
+            "exact match for key {key} must have distance 0"
+        );
+        assert_eq!(
+            record.search_id(),
+            key,
+            "index desync: searching key {key} returned record for key {}",
+            record.search_id()
+        );
+    }
+}

--- a/tests/tlsh_correctness.rs
+++ b/tests/tlsh_correctness.rs
@@ -1,0 +1,119 @@
+// TLSH correctness tests for APOTHEOSIS 2
+//
+// The rest of the suite runs on u32/NormalDistance, a degenerate 1-D metric
+// space. These tests exercise the actual production domain: TLSH digests with
+// TlshDistance. Digests are built deterministically in-test from seeded
+// buffers, so no external dataset file is needed.
+
+use apotheosis2::controllers::apotheosis::Apotheosis;
+use apotheosis2::datalayer::algorithms::TlshDistance;
+use apotheosis2::datalayer::record::SimpleTlshRecord;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use tlsh2::{TlshDefault, TlshDefaultBuilder};
+
+type ApoTlsh = Apotheosis<SimpleTlshRecord, TlshDistance>;
+
+// Deterministic TLSH digests: 1 KiB random buffers from a fixed seed. TLSH
+// needs at least 50 bytes with enough entropy; 1 KiB of PRNG output always
+// produces a valid digest.
+fn build_digests(count: usize) -> Vec<TlshDefault> {
+    let mut rng = StdRng::seed_from_u64(7);
+    (0..count)
+        .map(|_| {
+            let buf: Vec<u8> = (0..1024).map(|_| rng.r#gen::<u8>()).collect();
+            TlshDefaultBuilder::build_from(&buf).expect("1 KiB random buffer must produce a TLSH")
+        })
+        .collect()
+}
+
+fn hash_string(digest: &TlshDefault) -> String {
+    String::from_utf8(digest.hash().to_vec()).expect("TLSH hash is ASCII hex")
+}
+
+// ---------------------------------------------------------------------------
+// Exact match through the radix fast-path with real TLSH keys.
+// ---------------------------------------------------------------------------
+#[test]
+fn tlsh_exact_match_returns_inserted_record() {
+    let digests = build_digests(30);
+    let mut idx = ApoTlsh::new();
+    for d in &digests {
+        idx.insert(SimpleTlshRecord::create(hash_string(d)));
+    }
+
+    for d in &digests {
+        let results = idx.search(d, 1, None);
+        assert!(!results.is_empty(), "exact TLSH search returned nothing");
+        assert_eq!(results[0].0, 0, "exact TLSH match must have distance 0");
+        assert_eq!(
+            results[0].1.radix_key,
+            hash_string(d),
+            "index desync: exact TLSH search returned another record"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ANN path on TLSH space agrees with brute force on the nearest neighbor.
+// ---------------------------------------------------------------------------
+#[test]
+fn tlsh_ann_nearest_matches_brute_force() {
+    let digests = build_digests(60);
+    let (dataset, queries) = digests.split_at(50);
+
+    let mut idx = ApoTlsh::new();
+    for d in dataset {
+        idx.insert(SimpleTlshRecord::create(hash_string(d)));
+    }
+
+    let dist = TlshDistance;
+    for q in queries {
+        let results = idx.search(q, 5, Some(100));
+        assert!(!results.is_empty(), "TLSH ANN search returned nothing");
+
+        use apotheosis2::datalayer::algorithms::DistanceAlgorithm;
+        let brute_min = dataset
+            .iter()
+            .map(|d| dist.calculate_distance(d, q))
+            .min()
+            .unwrap();
+        assert_eq!(
+            results[0].0, brute_min,
+            "TLSH ANN nearest must match brute-force nearest"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// dump/load roundtrip preserves TLSH search results (serde path for TLSH).
+// ---------------------------------------------------------------------------
+#[test]
+fn tlsh_dump_load_roundtrip_preserves_results() {
+    use std::fs;
+
+    let path = "target/test_tlsh_roundtrip.bin";
+    let digests = build_digests(20);
+    let mut idx = ApoTlsh::new();
+    for d in &digests {
+        idx.insert(SimpleTlshRecord::create(hash_string(d)));
+    }
+
+    let query = &digests[3];
+    let before: Vec<u32> = idx
+        .search(query, 3, Some(50))
+        .iter()
+        .map(|(d, _)| *d)
+        .collect();
+
+    idx.dump(path).expect("dump() must not fail");
+    let loaded = ApoTlsh::load(path).expect("load() must not fail");
+    let after: Vec<u32> = loaded
+        .search(query, 3, Some(50))
+        .iter()
+        .map(|(d, _)| *d)
+        .collect();
+
+    fs::remove_file(path).ok();
+    assert_eq!(before, after, "TLSH results must survive dump/load");
+}


### PR DESCRIPTION
## Summary

Only one test existed (tests/api_contract.rs, from #8) and the two benchmark bins are not run in CI (need an external dataset file). No automated coverage of ANN recall, the shared-index invariant beyond length checks, neighbor-list eviction, or the TLSH domain.

## Changes

- `tests/ann_correctness.rs`: ANN recall vs brute force over 40 queries (mean recall >= 0.9, exact nearest-neighbor distance on every query), multi-layer search correctness, heuristic vs greedy graph divergence.
- `tests/fitness_functions.rs`: architectural invariants, including a test that every inserted key resolves through exact search to its own record (not just that `records.len()` and the graph node count match, which passes even if entries are crossed).
- `tests/config_matrix.rs`: default/small/heuristic configurations across sync invariant, exact match, roundtrip and cross-config header validation.
- `tests/config_boundary.rs`: boundary M/M0/EF values, plus a saturation test (300 inserts, M0=8) that forces the neighbor-list eviction branch in `connect_neighbors` to run repeatedly, verifying the graph stays exact afterward.
- `tests/tlsh_correctness.rs` (new): exact match, ANN vs brute force, and dump/load roundtrip on TLSH digests built deterministically in-test (no external dataset needed). The rest of the suite runs on a 1-D u32 metric space; this exercises the actual production domain.
- `tests/api_contract.rs`: public API contracts (dump/load error paths, k edge cases, draw() output). Supersedes the file from #8 (same empty-index case, plus more).

## Test plan

- [x] `cargo test` passes: 47 tests, 0 failures, verified locally batch by batch.
- [ ] `cargo clippy` on tests could not be verified locally (unrelated toolchain issue on this machine); will be validated by CI on this PR.

Closes #21