### PR TITLE
refactor: extract GEXF export from the Apotheosis facade (closes #18)

### DIFF
--- a/src/controllers/apotheosis.rs
+++ b/src/controllers/apotheosis.rs
@@ -7,10 +7,9 @@ use crate::controllers::hnsw::Hnsw;
 use crate::controllers::radix_tree::RadixNode;
 use crate::datalayer::algorithms::DistanceAlgorithm;
 use crate::datalayer::record::{ApotheosisRecord, RadixKeyMapping};
-use gexf::{Edge, EdgeType, Gexf, Node as GefxNode};
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(bound(
@@ -102,6 +101,21 @@ where
     /// Whether the model has no records indexed yet.
     pub fn is_empty(&self) -> bool {
         self.records.is_empty()
+    }
+
+    /// Structural view of the HNSW graph, one entry per layer: node feature
+    /// indices and their edges (source id, target id, distance). Needed by
+    /// `export::gexf`, which lives outside this impl and cannot reach `hnsw`
+    /// directly now that it is private.
+    #[allow(clippy::type_complexity)]
+    pub fn draw_model(&self) -> Vec<(Vec<usize>, Vec<(String, String, f32)>)> {
+        self.hnsw.draw_model()
+    }
+
+    /// Read-only access to a record by its index. Node indices returned by
+    /// `draw_model()` can be resolved to their full records through this.
+    pub fn record(&self, index: usize) -> Option<&R> {
+        self.records.get(index)
     }
 
     /// Performs an approximate k-NN search. If the `MetricId` natively maps to a Radix Tree key
@@ -199,92 +213,5 @@ where
 
         let decoded = bincode::deserialize_from(file)?;
         Ok(decoded)
-    }
-
-    // Exports the HNSW model to GEXF files for Gephi visualization.
-    /// Creates one file per layer with pattern `<path>_layer<N>.gexf`.
-    /// Nodes include all metadata attributes, edges represent HNSW connections.
-    ///
-    /// # Parameters
-    /// * `path` - Base filename for output (e.g., "model" creates "model_layer0.gexf", "model_layer1.gexf", etc.)
-    pub fn draw<P: AsRef<Path>>(&self, path: P) {
-        let base_path = path.as_ref();
-
-        let layer_gexfs = self.hnsw.draw_model();
-
-        // Enrich each layer with feature data and save
-        for (layer_idx, (nodes, edges)) in layer_gexfs.iter().enumerate() {
-            let mut gexf = Gexf::new(EdgeType::Undirected);
-            for node in nodes {
-                let mut gexf_node = GefxNode::new(node.to_string());
-                for (key, val) in self.records[*node].get_attributes() {
-                    gexf_node = gexf_node.with_attr(key, val);
-                }
-                let _ = gexf.add_node(gexf_node);
-            }
-
-            for (source_id, target_id, distance) in edges {
-                let _ = gexf.add_edge(
-                    Edge::new(
-                        format!("e_{}_{}", source_id, target_id),
-                        source_id.clone(),
-                        target_id.clone(),
-                    )
-                    .with_weight(*distance),
-                );
-            }
-
-            let _ = self.save_gexf(base_path, layer_idx, &gexf);
-        }
-    }
-
-    // Once draw is built, we need to add the attribute schema to the GEXF XML
-    // Has to be done manually since gexf crate does not support it yet.
-    fn add_attribute_schema(&self, xml: String, attributes: Vec<(String, String)>) -> String {
-        if let Some(graph_start) = xml.find("<graph")
-            && let Some(graph_end_offset) = xml[graph_start..].find(">")
-        {
-            let insert_pos = graph_start + graph_end_offset + 1;
-
-            let mut attrs = String::from("\n    <attributes class=\"node\">\n");
-            for (attribute_key, _) in attributes {
-                attrs.push_str(&format!(
-                    "      <attribute id=\"{}\" title=\"{}\" type=\"string\"/>\n",
-                    attribute_key, attribute_key
-                ));
-            }
-            attrs.push_str("    </attributes>\n");
-
-            let mut result = String::new();
-            result.push_str(&xml[..insert_pos]);
-            result.push_str(&attrs);
-            result.push_str(&xml[insert_pos..]);
-
-            return result;
-        }
-
-        xml
-    }
-
-    fn save_gexf(&self, base_path: &Path, layer_idx: usize, gexf: &Gexf) -> std::io::Result<()> {
-        let mut file_path = PathBuf::from(base_path);
-
-        if let Some(stem) = file_path.file_stem().and_then(|s| s.to_str()) {
-            let parent = file_path.parent().unwrap_or_else(|| Path::new(""));
-            let filename = format!("{}_layer{}.gexf", stem, layer_idx);
-            file_path = parent.join(filename);
-        } else {
-            let filename = format!("layer{}.gexf", layer_idx);
-            file_path = PathBuf::from(filename);
-        }
-
-        let fixed_xml = if !self.records.is_empty() {
-            self.add_attribute_schema(gexf.to_string().unwrap(), self.records[0].get_attributes())
-        } else {
-            gexf.to_string().unwrap()
-        };
-
-        fs::write(file_path, fixed_xml)?;
-        Ok(())
     }
 }

--- a/src/export/gexf.rs
+++ b/src/export/gexf.rs
@@ -1,0 +1,118 @@
+// AUTHORS: Daniel Huici and Ricardo J. Rodríguez
+// Copyright (c) 2025 - 2026
+// GPLv3 License
+// reverseame@unizar.es
+
+use crate::controllers::apotheosis::Apotheosis;
+use crate::datalayer::algorithms::DistanceAlgorithm;
+use crate::datalayer::record::ApotheosisRecord;
+use gexf::{Edge, EdgeType, Gexf, Node as GefxNode};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Exports the HNSW model to GEXF files for Gephi visualization.
+/// Creates one file per layer with pattern `<path>_layer<N>.gexf`.
+/// Nodes include all metadata attributes, edges represent HNSW connections.
+///
+/// # Parameters
+/// * `model` - The Apotheosis model to export
+/// * `path` - Base filename for output (e.g., "model" creates "model_layer0.gexf", "model_layer1.gexf", etc.)
+pub fn draw<R, D, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool, P>(
+    model: &Apotheosis<R, D, M, M0, EF, HEURISTIC>,
+    path: P,
+) where
+    R: ApotheosisRecord,
+    D: DistanceAlgorithm<R::MetricId> + Default,
+    P: AsRef<Path>,
+{
+    let base_path = path.as_ref();
+
+    let layer_gexfs = model.draw_model();
+
+    // Enrich each layer with feature data and save
+    for (layer_idx, (nodes, edges)) in layer_gexfs.iter().enumerate() {
+        let mut gexf = Gexf::new(EdgeType::Undirected);
+        for node in nodes {
+            let mut gexf_node = GefxNode::new(node.to_string());
+            let record = model
+                .record(*node)
+                .expect("node feature index out of range");
+            for (key, val) in record.get_attributes() {
+                gexf_node = gexf_node.with_attr(key, val);
+            }
+            let _ = gexf.add_node(gexf_node);
+        }
+
+        for (source_id, target_id, distance) in edges {
+            let _ = gexf.add_edge(
+                Edge::new(
+                    format!("e_{}_{}", source_id, target_id),
+                    source_id.clone(),
+                    target_id.clone(),
+                )
+                .with_weight(*distance),
+            );
+        }
+
+        let _ = save_gexf(model, base_path, layer_idx, &gexf);
+    }
+}
+
+// Once draw is built, we need to add the attribute schema to the GEXF XML
+// Has to be done manually since gexf crate does not support it yet.
+fn add_attribute_schema(xml: String, attributes: Vec<(String, String)>) -> String {
+    if let Some(graph_start) = xml.find("<graph") {
+        if let Some(graph_end_offset) = xml[graph_start..].find(">") {
+            let insert_pos = graph_start + graph_end_offset + 1;
+
+            let mut attrs = String::from("\n    <attributes class=\"node\">\n");
+            for (attribute_key, _) in attributes {
+                attrs.push_str(&format!(
+                    "      <attribute id=\"{}\" title=\"{}\" type=\"string\"/>\n",
+                    attribute_key, attribute_key
+                ));
+            }
+            attrs.push_str("    </attributes>\n");
+
+            let mut result = String::new();
+            result.push_str(&xml[..insert_pos]);
+            result.push_str(&attrs);
+            result.push_str(&xml[insert_pos..]);
+
+            return result;
+        }
+    }
+
+    xml
+}
+
+fn save_gexf<R, D, const M: usize, const M0: usize, const EF: usize, const HEURISTIC: bool>(
+    model: &Apotheosis<R, D, M, M0, EF, HEURISTIC>,
+    base_path: &Path,
+    layer_idx: usize,
+    gexf: &Gexf,
+) -> std::io::Result<()>
+where
+    R: ApotheosisRecord,
+    D: DistanceAlgorithm<R::MetricId> + Default,
+{
+    let mut file_path = PathBuf::from(base_path);
+
+    if let Some(stem) = file_path.file_stem().and_then(|s| s.to_str()) {
+        let parent = file_path.parent().unwrap_or_else(|| Path::new(""));
+        let filename = format!("{}_layer{}.gexf", stem, layer_idx);
+        file_path = parent.join(filename);
+    } else {
+        let filename = format!("layer{}.gexf", layer_idx);
+        file_path = PathBuf::from(filename);
+    }
+
+    let fixed_xml = if let Some(first_record) = model.record(0) {
+        add_attribute_schema(gexf.to_string().unwrap(), first_record.get_attributes())
+    } else {
+        gexf.to_string().unwrap()
+    };
+
+    fs::write(file_path, fixed_xml)?;
+    Ok(())
+}

--- a/src/export/gexf.rs
+++ b/src/export/gexf.rs
@@ -61,26 +61,26 @@ pub fn draw<R, D, const M: usize, const M0: usize, const EF: usize, const HEURIS
 // Once draw is built, we need to add the attribute schema to the GEXF XML
 // Has to be done manually since gexf crate does not support it yet.
 fn add_attribute_schema(xml: String, attributes: Vec<(String, String)>) -> String {
-    if let Some(graph_start) = xml.find("<graph") {
-        if let Some(graph_end_offset) = xml[graph_start..].find(">") {
-            let insert_pos = graph_start + graph_end_offset + 1;
+    if let Some(graph_start) = xml.find("<graph")
+        && let Some(graph_end_offset) = xml[graph_start..].find(">")
+    {
+        let insert_pos = graph_start + graph_end_offset + 1;
 
-            let mut attrs = String::from("\n    <attributes class=\"node\">\n");
-            for (attribute_key, _) in attributes {
-                attrs.push_str(&format!(
-                    "      <attribute id=\"{}\" title=\"{}\" type=\"string\"/>\n",
-                    attribute_key, attribute_key
-                ));
-            }
-            attrs.push_str("    </attributes>\n");
-
-            let mut result = String::new();
-            result.push_str(&xml[..insert_pos]);
-            result.push_str(&attrs);
-            result.push_str(&xml[insert_pos..]);
-
-            return result;
+        let mut attrs = String::from("\n    <attributes class=\"node\">\n");
+        for (attribute_key, _) in attributes {
+            attrs.push_str(&format!(
+                "      <attribute id=\"{}\" title=\"{}\" type=\"string\"/>\n",
+                attribute_key, attribute_key
+            ));
         }
+        attrs.push_str("    </attributes>\n");
+
+        let mut result = String::new();
+        result.push_str(&xml[..insert_pos]);
+        result.push_str(&attrs);
+        result.push_str(&xml[insert_pos..]);
+
+        return result;
     }
 
     xml

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -3,6 +3,4 @@
 // GPLv3 License
 // reverseame@unizar.es
 
-pub mod controllers;
-pub mod datalayer;
-pub mod export;
+pub mod gexf;


### PR DESCRIPTION
## Summary

`apotheosis.rs` mixed index coordination, persistence and GEXF visualization export (about 85 of its 250 lines, including manual XML string patching). Any change to the export format touched the same file holding the critical insert/search logic.

## Changes

- `src/export/gexf.rs` (new): `draw()`, `add_attribute_schema()` and `save_gexf()` moved unchanged, now a free function `export::gexf::draw(&model, path)` consuming the facade through its public API.
- `src/controllers/apotheosis.rs`: `draw()` removed. Two read-only accessors added: `draw_model()` (graph shape, one entry per layer) and `record(index)`. Both are needed by `export::gexf::draw()`, which lives outside this impl and cannot reach `hnsw`/`records` directly now that they are private (#14/#15).
- `src/lib.rs`: `pub mod export;`.

Breaking change, declared: callers of `model.draw(path)` move to `export::gexf::draw(&model, path)`. Verified nothing in this repo calls `draw()` besides its own definition.

## Test plan

Test coverage for this refactor will be added as part of the dedicated test suite work (tests are being consolidated separately instead of per-PR).

- [x] `cargo test`, `cargo check` pass locally.
- [x] `rustfmt --check` on the three changed files (`apotheosis.rs`, `export/gexf.rs`, `export/mod.rs`) passes. (`src/lib.rs` was excluded from the direct rustfmt check since it cascades to the whole module tree including unrelated pre-existing files.)
- [ ] `cargo clippy` on the full crate could not be verified locally (unrelated toolchain issue on this machine); will be validated by CI on this PR.

Closes #18