### PR TITLE
fix: return Result from record constructors instead of panicking (closes #26)

### DIFF
--- a/src/bin/test_numbers.rs
+++ b/src/bin/test_numbers.rs
@@ -22,7 +22,9 @@ pub fn main() {
     // println!("Queries: {:?}", random_queries);
 
     for &n in &random_numbers {
-        features.push(SimpleNumberRecord::create(n.to_string()))
+        features.push(
+            SimpleNumberRecord::create(n.to_string()).expect("internally generated, always valid"),
+        )
     }
 
     let creation_start = Instant::now();

--- a/src/bin/test_tlsh.rs
+++ b/src/bin/test_tlsh.rs
@@ -47,7 +47,9 @@ pub fn main() {
     );
     println!("Starting insertion into HNSW model...");
     for f in dataset_copy {
-        apotheosis.insert(SimpleTlshRecord::create(f));
+        apotheosis.insert(
+            SimpleTlshRecord::create(f).expect("hash from output_hashes.json, always valid"),
+        );
     }
 
     let query_hash = TlshDefault::from_str(

--- a/src/controllers/apotheosis.rs
+++ b/src/controllers/apotheosis.rs
@@ -81,7 +81,7 @@ where
         if let Some(ref key) = radix_key
             && self.radix.find(key).is_some()
         {
-            println!("Key already exists in radix tree: {:?}", key);
+            tracing::warn!("Key already exists in radix tree: {:?}", key);
             return false;
         }
 

--- a/src/datalayer.rs
+++ b/src/datalayer.rs
@@ -1,3 +1,4 @@
 pub mod algorithms;
+pub mod error;
 pub mod nodes;
 pub mod record;

--- a/src/datalayer/error.rs
+++ b/src/datalayer/error.rs
@@ -1,0 +1,39 @@
+use std::fmt;
+use std::num::ParseIntError;
+
+/// Error returned when constructing a record from an untrusted string, e.g. a
+/// line read from a dataset file. Record constructors return this instead of
+/// panicking so a malformed entry can be skipped without aborting the whole
+/// ingestion.
+#[derive(Debug)]
+pub enum RecordError {
+    /// The input was expected to be a `u32` but did not parse as one.
+    InvalidNumber {
+        input: String,
+        source: ParseIntError,
+    },
+    /// The input was expected to be a TLSH digest but did not parse as one.
+    InvalidTlshHash { input: String },
+}
+
+impl fmt::Display for RecordError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecordError::InvalidNumber { input, source } => {
+                write!(f, "invalid number record {input:?}: {source}")
+            }
+            RecordError::InvalidTlshHash { input } => {
+                write!(f, "invalid TLSH hash {input:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RecordError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RecordError::InvalidNumber { source, .. } => Some(source),
+            RecordError::InvalidTlshHash { .. } => None,
+        }
+    }
+}

--- a/src/datalayer/record.rs
+++ b/src/datalayer/record.rs
@@ -1,3 +1,4 @@
+use crate::datalayer::error::RecordError;
 use std::str::FromStr;
 use tlsh2::TlshDefault;
 
@@ -53,16 +54,28 @@ pub type SimpleNumberRecord = SimpleRecord<u32>;
 pub type SimpleTlshRecord = SimpleRecord<TlshDefault>;
 
 impl SimpleNumberRecord {
-    pub fn create(s: String) -> Self {
-        let id = s.parse::<u32>().unwrap();
-        Self { id, radix_key: s }
+    /// Builds a record from an untrusted string (e.g. a line read from a
+    /// dataset file). Returns `Err` instead of panicking so a malformed entry
+    /// can be skipped without aborting the whole ingestion.
+    pub fn create(s: String) -> Result<Self, RecordError> {
+        let id = s
+            .parse::<u32>()
+            .map_err(|source| RecordError::InvalidNumber {
+                input: s.clone(),
+                source,
+            })?;
+        Ok(Self { id, radix_key: s })
     }
 }
 
 impl SimpleTlshRecord {
-    pub fn create(s: String) -> Self {
-        let id = TlshDefault::from_str(&s).unwrap();
-        Self { id, radix_key: s }
+    /// Builds a record from an untrusted TLSH hash string. Returns `Err`
+    /// instead of panicking so a malformed entry can be skipped without
+    /// aborting the whole ingestion.
+    pub fn create(s: String) -> Result<Self, RecordError> {
+        let id = TlshDefault::from_str(&s)
+            .map_err(|_| RecordError::InvalidTlshHash { input: s.clone() })?;
+        Ok(Self { id, radix_key: s })
     }
 }
 
@@ -99,13 +112,17 @@ impl ApotheosisRecord for GenericJsonRecord {
 }
 
 impl GenericJsonRecord {
-    pub fn create(s: String, metadata: serde_json::Value) -> Self {
-        let id = TlshDefault::from_str(&s).unwrap();
-        Self {
+    /// Builds a record from an untrusted TLSH hash string. Returns `Err`
+    /// instead of panicking so a malformed entry can be skipped without
+    /// aborting the whole ingestion.
+    pub fn create(s: String, metadata: serde_json::Value) -> Result<Self, RecordError> {
+        let id = TlshDefault::from_str(&s)
+            .map_err(|_| RecordError::InvalidTlshHash { input: s.clone() })?;
+        Ok(Self {
             id,
             radix_key: s,
             metadata,
-        }
+        })
     }
 }
 

--- a/tests/record_construction.rs
+++ b/tests/record_construction.rs
@@ -1,0 +1,45 @@
+// create() constructors build records from untrusted strings (e.g. a line
+// read from a dataset file). They must return Err on malformed input instead
+// of panicking, so a single bad entry does not abort a whole ingestion run.
+
+use apotheosis2::datalayer::record::{GenericJsonRecord, SimpleNumberRecord, SimpleTlshRecord};
+
+#[test]
+fn number_record_rejects_non_numeric_input() {
+    let result = SimpleNumberRecord::create("not-a-number".to_string());
+    assert!(result.is_err(), "malformed number input must return Err");
+
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("not-a-number"),
+        "error message must include the offending input, got: {msg}"
+    );
+}
+
+#[test]
+fn number_record_accepts_valid_input() {
+    let result = SimpleNumberRecord::create("42".to_string());
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().id, 42);
+}
+
+#[test]
+fn tlsh_record_rejects_malformed_hash() {
+    let result = SimpleTlshRecord::create("not-a-tlsh-hash".to_string());
+    assert!(result.is_err(), "malformed TLSH hash must return Err");
+
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("not-a-tlsh-hash"),
+        "error message must include the offending input, got: {msg}"
+    );
+}
+
+#[test]
+fn generic_json_record_rejects_malformed_hash() {
+    let result = GenericJsonRecord::create(
+        "not-a-tlsh-hash".to_string(),
+        serde_json::json!({"key": "value"}),
+    );
+    assert!(result.is_err(), "malformed TLSH hash must return Err");
+}


### PR DESCRIPTION
## Summary

`SimpleNumberRecord::create`, `SimpleTlshRecord::create` and `GenericJsonRecord::create` build records from untrusted strings (e.g. a line read from a dataset file), but used `unwrap()` on the parse step. Verified empirically: feeding malformed input to the pre-fix logic panics the process (exit code 101), aborting a whole ingestion run over a single bad entry.

Also: `insert()` used `println!` to warn about a duplicate key instead of the `tracing` crate already used elsewhere in the codebase.

## Changes

- `src/datalayer/error.rs` (new): `RecordError` (`InvalidNumber`, `InvalidTlshHash`), each variant carrying the offending input string. Implements `Display` and `std::error::Error`.
- `src/datalayer/record.rs`: all three constructors now return `Result<Self, RecordError>` instead of panicking.
- `src/controllers/apotheosis.rs`: `insert()` uses `tracing::warn!` instead of `println!`.
- `src/bin/test_numbers.rs`, `test_tlsh.rs`: updated to the new signature with `.expect(...)` (internally generated / pre-validated data, not user input).

Scope note: `dump()`/`load()` still return `Box<dyn std::error::Error>` rather than a typed error. Left out of this PR since it overlaps with #24 (open, rewrites `load()`); a unified error type across persistence and record construction is a natural follow-up once that merges.

## Test plan

- [x] `tests/record_construction.rs` (new, 4 tests): malformed input returns `Err` with the offending input in the message; valid input returns `Ok`.
- [x] `cargo test`, `cargo clippy --all-targets --all-features -- -D warnings`, `rustfmt --check` all pass locally.
- [x] Manually verified pre-fix behavior: same malformed input against the old `unwrap()`-based logic panics (exit code 101); post-fix returns `Err` and the process continues.

Closes #26